### PR TITLE
Update BMW 3 Series generations: correct production years and add eighth generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # BMW 3 Series
 
+This repository contains signal set configurations for the BMW 3 Series, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the BMW 3 Series.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/BMW_3_Series"
+
 generations:
   - name: "First Generation (E21)"
     start_year: 1975
@@ -20,16 +23,21 @@ generations:
     description: "Widely considered a high point for the 3 Series, the E46 balanced modern technology with traditional BMW driving dynamics. Available in sedan, coupe, convertible, wagon, and compact body styles, it featured refined straight-six engines and improved interior quality. The E46 M3 with its 333 HP 3.2L straight-six is particularly revered. This generation combined mechanical purity with modern comfort and technology."
 
   - name: "Fifth Generation (E90/E91/E92/E93)"
-    start_year: 2005
-    end_year: 2013
+    start_year: 2004
+    end_year: 2012
     description: "The fifth-generation 3 Series comprised the E90 sedan, E91 wagon, E92 coupe, and E93 convertible (with a folding hardtop). It introduced run-flat tires, advanced electronic systems, and turbocharged engines on non-M models. The M3 featured a high-revving 4.0L V8. While more technologically advanced than its predecessors, some enthusiasts felt it lost some of the traditional BMW handling feel."
 
-  - name: "Sixth Generation (F30/F31/F34)"
-    start_year: 2012
+  - name: "Sixth Generation (F30/F31/F34/F35)"
+    start_year: 2011
     end_year: 2019
     description: "The F30 generation separated the 3 Series sedan and wagon from the coupe and convertible (which became the 4 Series). It introduced a wider range of turbocharged engines, electric power steering, and significantly more technology. The F34 Gran Turismo offered a more practical fastback body style. The M3 returned to a straight-six engine, now twin-turbocharged with 425-450 HP. This generation focused on efficiency and technology while attempting to maintain BMW's driving dynamics."
 
-  - name: "Seventh Generation (G20/G21)"
-    start_year: 2019
+  - name: "Seventh Generation (G20/G21/G28)"
+    start_year: 2018
     end_year: null
     description: "The current 3 Series features more aggressive styling, improved dynamics with a stiffer chassis, and advanced technology including partially automated driving capabilities. Engine options range from three-cylinder to six-cylinder units, with hybrid options available. The interior features BMW's latest iDrive system and digital displays. The G20 generation refocused on driver engagement following criticism of the F30. The M3 offers up to 503 HP in Competition form, with optional all-wheel drive for the first time. Throughout its evolution, the 3 Series has remained BMW's core model, embodying the brand's 'Ultimate Driving Machine' ethos while adapting to changing market demands."
+
+  - name: "Eighth Generation (G50/G51/NA0)"
+    start_year: 2026
+    end_year: null
+    description: "The eighth generation of the BMW 3 Series lineup consists of internationally available ICE (internal combustion engine) and BEV (battery electric) versions. The G50 is the conventional gasoline/hybrid variant, while the NA0 is the battery electric variant exclusive for the Chinese market as the i3. The G50 is rumored to receive a touring bodystyle (G51), while the NA0 is rumored to receive a China-exclusive long-wheelbase variant (NA8). Performance-oriented M3 models are planned for both ICE and BEV versions. Following the 'Neue Klasse' design language introduced with the iX3, the G50 will embrace a radical and retro design makeover, new interior layout, and all-new driving technology."


### PR DESCRIPTION
- Fifth Generation (E90/E91/E92/E93): Corrected start year from 2005 to 2004, end year from 2013 to 2012
- Sixth Generation (F30/F31/F34/F35): Corrected start year from 2012 to 2011, added F35 designation
- Seventh Generation (G20/G21/G28): Corrected start year from 2019 to 2018, added G28 designation
- Added Eighth Generation (G50/G51/NA0) launching in 2026 with ICE and BEV variants
- Updated references to use BMW 3 Series Wikipedia article
- Updated README.md with standard template

Evidence: Wikipedia article confirms E90 production began in 2004 (not 2005), ended in 2012; F30 started in 2011; G20 unveiled October 2, 2018; eighth generation (G50/NA0) launching 2026.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
